### PR TITLE
cos-csi support specifying directory of bucket

### DIFF
--- a/docs/README_COSFS.md
+++ b/docs/README_COSFS.md
@@ -128,6 +128,8 @@ spec:
       url: "http://cos.ap-guangzhou.myqcloud.com"
       # Replaced by the bucket name you want to use.
       bucket: "testbucket-1010101010"
+      # You can specify sub-directory of bucket in cosfs command in here.
+      # path: "/my-dir"
       # You can specify any other options used by the cosfs command in here.
       #additional_args: "-oallow_other"
     nodePublishSecretRef:

--- a/driver/cosfs/mounter.go
+++ b/driver/cosfs/mounter.go
@@ -140,8 +140,12 @@ func sendCmdToLauncher(options *cosfsOptions, mountPoint string, credentialFileP
 		},
 	}
 
+	bucketOrWithSubDir := options.Bucket
+	if options.Path != "" {
+		bucketOrWithSubDir = fmt.Sprintf("%s:%s", options.Bucket, options.Path)
+	}
 	args := []string{
-		options.Bucket,
+		bucketOrWithSubDir,
 		mountPoint,
 		"-ourl=" + options.URL,
 		"-odbglevel=" + options.DebugLevel,

--- a/driver/cosfs/nodeserver.go
+++ b/driver/cosfs/nodeserver.go
@@ -65,6 +65,7 @@ type nodeServer struct {
 type cosfsOptions struct {
 	URL            string
 	Bucket         string
+	Path           string
 	DebugLevel     string
 	AdditionalArgs string
 }
@@ -152,6 +153,8 @@ func parseCosfsOptions(attributes map[string]string) (*cosfsOptions, error) {
 			options.URL = v
 		case "bucket":
 			options.Bucket = v
+		case "path":
+			options.Path = v
 		case "dbglevel":
 			options.DebugLevel = v
 		case "additional_args":


### PR DESCRIPTION
can specify "/my-dir" of bucket in pv.yaml. e.g. "cosfs examplebucket-1250000000:/my-dir /mnt/cosfs -ourl=http://cos.ap-guangzhou.myqcloud.com -odbglevel=info"
