### PR TITLE
optimizations for cbs csi

### DIFF
--- a/Dockerfile.cfs
+++ b/Dockerfile.cfs
@@ -1,4 +1,4 @@
-FROM golang:1.12.7-stretch as builder
+FROM golang:1.14.1-stretch as builder
 WORKDIR /go/src/github.com/tencentcloud/kubernetes-csi-tencentcloud
 ADD . .
 RUN go build -v --ldflags ' -extldflags "-static"' -o csi-tencentcloud-cfs cmd/cfs/main.go 

--- a/cmd/cbs/main.go
+++ b/cmd/cbs/main.go
@@ -23,8 +23,6 @@ const (
 
 var (
 	endpoint          = flag.String("endpoint", fmt.Sprintf("unix:///var/lib/kubelet/plugins/%s/csi.sock", cbs.DriverName), "CSI endpoint")
-	secretId          = flag.String("secret_id", "", "tencent cloud api secret id")
-	secretKey         = flag.String("secret_key", "", "tencent cloud api secret key")
 	region            = flag.String("region", "", "tencent cloud api region")
 	zone              = flag.String("zone", "", "cvm instance region")
 	cbsUrl            = flag.String("cbs_url", "cbs.internal.tencentcloudapi.com", "cbs api domain")
@@ -52,21 +50,6 @@ func main() {
 		zone = &z
 	}
 
-	if *secretId == "" {
-		if secretIdFromEnv := os.Getenv(TENCENTCLOUD_CBS_API_SECRET_ID); secretIdFromEnv != "" {
-			secretId = &secretIdFromEnv
-		}
-	}
-	if *secretKey == "" {
-		if secretKeyFromEnv := os.Getenv(TENCENTCLOUD_CBS_API_SECRET_KEY); secretKeyFromEnv != "" {
-			secretKey = &secretKeyFromEnv
-		}
-	}
-
-	if *secretId == "" || *secretKey == "" {
-		glog.Fatal("tencent cloud credential must be specified")
-	}
-
 	u, err := url.Parse(*endpoint)
 	if err != nil {
 		glog.Fatalf("parse endpoint err: %s", err.Error())
@@ -78,7 +61,7 @@ func main() {
 
 	cp := util.NewCachePersister()
 
-	drv, err := cbs.NewDriver(*region, *zone, *secretId, *secretKey, os.Getenv(ClusterId), *volumeAttachLimit)
+	drv, err := cbs.NewDriver(*region, *zone, os.Getenv(ClusterId), *volumeAttachLimit)
 	if err != nil {
 		glog.Fatal(err)
 	}

--- a/cmd/cbs/main.go
+++ b/cmd/cbs/main.go
@@ -22,12 +22,13 @@ const (
 )
 
 var (
-	endpoint  = flag.String("endpoint", fmt.Sprintf("unix:///var/lib/kubelet/plugins/%s/csi.sock", cbs.DriverName), "CSI endpoint")
-	secretId  = flag.String("secret_id", "", "tencent cloud api secret id")
-	secretKey = flag.String("secret_key", "", "tencent cloud api secret key")
-	region    = flag.String("region", "", "tencent cloud api region")
-	zone      = flag.String("zone", "", "cvm instance region")
-	cbsUrl    = flag.String("cbs_url", "cbs.internal.tencentcloudapi.com", "cbs api domain")
+	endpoint          = flag.String("endpoint", fmt.Sprintf("unix:///var/lib/kubelet/plugins/%s/csi.sock", cbs.DriverName), "CSI endpoint")
+	secretId          = flag.String("secret_id", "", "tencent cloud api secret id")
+	secretKey         = flag.String("secret_key", "", "tencent cloud api secret key")
+	region            = flag.String("region", "", "tencent cloud api region")
+	zone              = flag.String("zone", "", "cvm instance region")
+	cbsUrl            = flag.String("cbs_url", "cbs.internal.tencentcloudapi.com", "cbs api domain")
+	volumeAttachLimit = flag.Int64("volume_attach_limit", -1, "Value for the maximum number of volumes attachable for all nodes. If the flag is not specified then the value is default 20.")
 )
 
 func main() {
@@ -77,7 +78,7 @@ func main() {
 
 	cp := util.NewCachePersister()
 
-	drv, err := cbs.NewDriver(*region, *zone, *secretId, *secretKey, os.Getenv(ClusterId))
+	drv, err := cbs.NewDriver(*region, *zone, *secretId, *secretKey, os.Getenv(ClusterId), *volumeAttachLimit)
 	if err != nil {
 		glog.Fatal(err)
 	}

--- a/cmd/cbs/main.go
+++ b/cmd/cbs/main.go
@@ -17,6 +17,8 @@ import (
 const (
 	TENCENTCLOUD_CBS_API_SECRET_ID  = "TENCENTCLOUD_CBS_API_SECRET_ID"
 	TENCENTCLOUD_CBS_API_SECRET_KEY = "TENCENTCLOUD_CBS_API_SECRET_KEY"
+
+	ClusterId = "CLUSTER_ID"
 )
 
 var (
@@ -75,7 +77,7 @@ func main() {
 
 	cp := util.NewCachePersister()
 
-	drv, err := cbs.NewDriver(*region, *zone, *secretId, *secretKey)
+	drv, err := cbs.NewDriver(*region, *zone, *secretId, *secretKey, os.Getenv(ClusterId))
 	if err != nil {
 		glog.Fatal(err)
 	}

--- a/deploy/cbs/kubernetes/csi-controller.yaml
+++ b/deploy/cbs/kubernetes/csi-controller.yaml
@@ -108,16 +108,18 @@ spec:
           env:
             - name: ADDRESS
               value: unix:///csi/csi.sock
-            - name: TENCENTCLOUD_CBS_API_SECRET_ID
+            - name: TENCENTCLOUD_API_SECRET_ID
               valueFrom:
                 secretKeyRef:
                   name: csi-tencentcloud
                   key: TENCENTCLOUD_CBS_API_SECRET_ID
-            - name: TENCENTCLOUD_CBS_API_SECRET_KEY
+                  optional: true
+            - name: TENCENTCLOUD_API_SECRET_KEY
               valueFrom:
                 secretKeyRef:
                   name: csi-tencentcloud
                   key: TENCENTCLOUD_CBS_API_SECRET_KEY
+                  optional: true
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/deploy/cbs/kubernetes/csi-controller.yaml
+++ b/deploy/cbs/kubernetes/csi-controller.yaml
@@ -122,6 +122,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+# for deleting cbs disks in cluster while deleting cluster
+#            - name: CLUSTER_ID
+#              value: cls-xxxxxx
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/docs/README_CBS.md
+++ b/docs/README_CBS.md
@@ -7,8 +7,8 @@
 * **Dynamic Provisioning** - use PVC to request the Kuberenetes to create the CBS disk on behalf of user and consumes the disk from inside container
     * specify zone - which zone the CBS disk will be provisioned in.
         * `allowedTopologies` - The topology key should be `topology.com.tencent.cloud.csi.cbs/zone`.
-        * `diskZone/diskZones` in `StorageClass.parameters` - the zone in `diskZone/diskZones` is prefered. Then, zone in `allowedTopologies`.
-    * **Topology-Aware** - create disk until pod has schedulered, and create disk in the zone which node in. the zone in `diskZone/diskZones` is prefered
+        * `diskZone` in `StorageClass.parameters` - the zone in `diskZone` is prefered. Then, zone in `allowedTopologies`.
+    * **Topology-Aware** - create disk until pod has schedulered, and create disk in the zone which node in. the zone in `diskZone` is prefered
 * **Volume Snapshot**
 * **Volume Resizing** - expand volume size
 * **Volume Attach Limit** - the maximum number of CBS disks that can be attached to one node.(20 CBS disks per node)

--- a/docs/README_CBS_zhCN.md
+++ b/docs/README_CBS_zhCN.md
@@ -7,8 +7,8 @@
 * **Dynamic Provisioning** - 在容器需要使用时，根据PVC去创建CBS盘
     * specify zone - 指定要在哪个zone创建CBS盘
         * `allowedTopologies` - topology key是`topology.com.tencent.cloud.csi.cbs/zone`.
-        * `diskZone/diskZones` in `StorageClass.parameters` - `diskZone/diskZones`中配置的zone优先级最高. 之后才是`allowedTopologies`中的zone
-    * **Topology-Aware** - pod被调度完以后，在相应node所在zone创建CBS盘. 如果同时`diskZone/diskZones`已配置，优先`diskZone/diskZones`
+        * `diskZone` in `StorageClass.parameters` - `diskZone`中配置的zone优先级最高. 之后才是`allowedTopologies`中的zone
+    * **Topology-Aware** - pod被调度完以后，在相应node所在zone创建CBS盘. 如果同时`diskZone`已配置，优先`diskZone`
 * **Volume Snapshot** - 磁盘快照
 * **Volume Resizing** - 磁盘扩容
 * **Volume Attach Limit** - 单节点最大能attach的CBS盘数量.(每个节点最大可attach 20块CBS盘)

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,3 @@
+## TKE CBS CSI Driver
+
+### Custom volume limits

--- a/driver/cbs/cbs_utils.go
+++ b/driver/cbs/cbs_utils.go
@@ -3,6 +3,10 @@ package cbs
 import (
 	"fmt"
 	"sync"
+
+	"github.com/tencentcloud/kubernetes-csi-tencentcloud/driver/util"
+	cbs "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cbs/v20170312"
+	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
 )
 
 type cbsSnapshot struct {
@@ -42,4 +46,17 @@ func getCbsSnapshotByName(snapName string) (*cbsSnapshot, error) {
 		}
 	}
 	return nil, fmt.Errorf("snapshot name %s does not exit in the snapshots list", snapName)
+}
+
+func updateCbsClent(client *cbs.Client) *cbs.Client {
+	secretID, secretKey, token, isTokenUpdate := util.GetSercet()
+	if token != "" && isTokenUpdate {
+		cred := common.Credential{
+			SecretId:  secretID,
+			SecretKey: secretKey,
+			Token:     token,
+		}
+		client.WithCredential(&cred)
+	}
+	return client
 }

--- a/driver/cbs/controller.go
+++ b/driver/cbs/controller.go
@@ -470,7 +470,9 @@ func (ctrl *cbsController) ControllerUnpublishVolume(ctx context.Context, req *c
 	}
 
 	if len(listCbsResponse.Response.DiskSet) <= 0 {
-		return nil, status.Error(codes.NotFound, "disk not found")
+		// return nil, status.Error(codes.NotFound, "disk not found")
+		glog.Warningf("ControllerUnpublishVolume: detach disk %s from node %s, but cbs disk does not exist; assuming the disk is detached", diskId, req.NodeId)
+		return &csi.ControllerUnpublishVolumeResponse{}, nil
 	}
 
 	for _, disk := range listCbsResponse.Response.DiskSet {

--- a/driver/cbs/controller.go
+++ b/driver/cbs/controller.go
@@ -1,6 +1,7 @@
 package cbs
 
 import (
+	"fmt"
 	"strconv"
 	"sync"
 	"time"
@@ -213,7 +214,11 @@ func (ctrl *cbsController) CreateVolume(ctx context.Context, req *csi.CreateVolu
 
 	createCbsReq := cbs.NewCreateDisksRequest()
 
-	createCbsReq.DiskName = &volumeIdempotencyName
+	diskName := volumeIdempotencyName
+	if ctrl.clusterId != "" {
+		diskName = fmt.Sprintf("%s/%s", ctrl.clusterId, volumeIdempotencyName)
+	}
+	createCbsReq.DiskName = common.StringPtr(diskName)
 	createCbsReq.ClientToken = &volumeIdempotencyName
 	createCbsReq.DiskType = &volumeType
 	createCbsReq.DiskChargeType = &volumeChargeType

--- a/driver/cbs/driver.go
+++ b/driver/cbs/driver.go
@@ -21,21 +21,17 @@ const (
 )
 
 type Driver struct {
-	region    string
-	zone      string
-	secretId  string
-	secretKey string
+	region string
+	zone   string
 	// TKE cluster ID
 	clusterId         string
 	volumeAttachLimit int64
 }
 
-func NewDriver(region, zone, secretId, secretKey, clusterId string, volumeAttachLimit int64) (*Driver, error) {
+func NewDriver(region, zone, clusterId string, volumeAttachLimit int64) (*Driver, error) {
 	driver := Driver{
 		zone:              zone,
 		region:            region,
-		secretId:          secretId,
-		secretKey:         secretKey,
 		clusterId:         clusterId,
 		volumeAttachLimit: volumeAttachLimit,
 	}
@@ -44,7 +40,7 @@ func NewDriver(region, zone, secretId, secretKey, clusterId string, volumeAttach
 }
 
 func (drv *Driver) Run(endpoint *url.URL, cbsUrl string, cachePersister util.CachePersister) error {
-	controller, err := newCbsController(drv.secretId, drv.secretKey, drv.region, drv.zone, cbsUrl, drv.clusterId, cachePersister)
+	controller, err := newCbsController(drv.region, drv.zone, cbsUrl, drv.clusterId, cachePersister)
 	if err != nil {
 		return err
 	}
@@ -58,7 +54,7 @@ func (drv *Driver) Run(endpoint *url.URL, cbsUrl string, cachePersister util.Cac
 		return err
 	}
 
-	node, err := newCbsNode(drv.secretId, drv.secretKey, drv.region, drv.volumeAttachLimit)
+	node, err := newCbsNode(drv.region, drv.volumeAttachLimit)
 	if err != nil {
 		return err
 	}

--- a/driver/cbs/driver.go
+++ b/driver/cbs/driver.go
@@ -25,16 +25,19 @@ type Driver struct {
 	zone      string
 	secretId  string
 	secretKey string
-	clusterId string
+	// TKE cluster ID
+	clusterId         string
+	volumeAttachLimit int64
 }
 
-func NewDriver(region, zone, secretId, secretKey, clusterId string) (*Driver, error) {
+func NewDriver(region, zone, secretId, secretKey, clusterId string, volumeAttachLimit int64) (*Driver, error) {
 	driver := Driver{
-		zone:      zone,
-		region:    region,
-		secretId:  secretId,
-		secretKey: secretKey,
-		clusterId: clusterId,
+		zone:              zone,
+		region:            region,
+		secretId:          secretId,
+		secretKey:         secretKey,
+		clusterId:         clusterId,
+		volumeAttachLimit: volumeAttachLimit,
 	}
 
 	return &driver, nil
@@ -55,7 +58,7 @@ func (drv *Driver) Run(endpoint *url.URL, cbsUrl string, cachePersister util.Cac
 		return err
 	}
 
-	node, err := newCbsNode(drv.secretId, drv.secretKey, drv.region)
+	node, err := newCbsNode(drv.secretId, drv.secretKey, drv.region, drv.volumeAttachLimit)
 	if err != nil {
 		return err
 	}

--- a/driver/cbs/driver.go
+++ b/driver/cbs/driver.go
@@ -25,21 +25,23 @@ type Driver struct {
 	zone      string
 	secretId  string
 	secretKey string
+	clusterId string
 }
 
-func NewDriver(region string, zone string, secretId string, secretKey string) (*Driver, error) {
+func NewDriver(region, zone, secretId, secretKey, clusterId string) (*Driver, error) {
 	driver := Driver{
 		zone:      zone,
 		region:    region,
 		secretId:  secretId,
 		secretKey: secretKey,
+		clusterId: clusterId,
 	}
 
 	return &driver, nil
 }
 
 func (drv *Driver) Run(endpoint *url.URL, cbsUrl string, cachePersister util.CachePersister) error {
-	controller, err := newCbsController(drv.secretId, drv.secretKey, drv.region, drv.zone, cbsUrl, cachePersister)
+	controller, err := newCbsController(drv.secretId, drv.secretKey, drv.region, drv.zone, cbsUrl, drv.clusterId, cachePersister)
 	if err != nil {
 		return err
 	}

--- a/driver/cbs/node.go
+++ b/driver/cbs/node.go
@@ -48,8 +48,15 @@ type cbsNode struct {
 }
 
 // TODO  node plugin need idempotent and should use inflight
-func newCbsNode(secretId, secretKey, region string, volumeAttachLimit int64) (*cbsNode, error) {
-	client, err := cbs.NewClient(common.NewCredential(secretId, secretKey), region, profile.NewClientProfile())
+func newCbsNode(region string, volumeAttachLimit int64) (*cbsNode, error) {
+	secretID, secretKey, token, _ := util.GetSercet()
+	cred := &common.Credential{
+		SecretId:  secretID,
+		SecretKey: secretKey,
+		Token:     token,
+	}
+
+	client, err := cbs.NewClient(cred, region, profile.NewClientProfile())
 	if err != nil {
 		return nil, err
 	}

--- a/driver/cfs/controller.go
+++ b/driver/cfs/controller.go
@@ -210,7 +210,7 @@ func (cs *controllerServer) ControllerExpandVolume(context.Context, *csi.Control
 }
 
 func updateCfsClent(client *cfsv3.Client) *cfsv3.Client {
-	secretID, secretKey, token, isTokenUpdate := GetSercet()
+	secretID, secretKey, token, isTokenUpdate := util.GetSercet()
 	if token != "" && isTokenUpdate {
 		cred := v3common.Credential{
 			SecretId:  secretID,

--- a/driver/cfs/driver.go
+++ b/driver/cfs/driver.go
@@ -20,6 +20,7 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/glog"
 	csicommon "github.com/kubernetes-csi/drivers/pkg/csi-common"
+	"github.com/tencentcloud/kubernetes-csi-tencentcloud/driver/util"
 	cfsv3 "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cfs/v20190719"
 	v3common "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
 	v3profile "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/profile"
@@ -79,7 +80,7 @@ func NewNodeServer(d *driver, mounter mount.Interface) *nodeServer {
 }
 
 func NewControllerServer(d *driver) *controllerServer {
-	secretID, secretKey, token, _ := GetSercet()
+	secretID, secretKey, token, _ := util.GetSercet()
 
 	cred := v3common.Credential{
 		SecretId:  secretID,

--- a/driver/cfs/utils.go
+++ b/driver/cfs/utils.go
@@ -1,33 +1,33 @@
 package cfs
 
-import (
-	"os"
+// import (
+// 	"os"
 
-	"github.com/golang/glog"
-	"github.com/tencentcloud/kubernetes-csi-tencentcloud/driver/cloud"
-)
+// 	"github.com/golang/glog"
+// 	"github.com/tencentcloud/kubernetes-csi-tencentcloud/driver/cloud"
+// )
 
-func GetSercet() (secretID, secretKey, token string, isTokenUpdate bool) {
-	secretID = os.Getenv("TENCENTCLOUD_API_SECRET_ID")
-	secretKey = os.Getenv("TENCENTCLOUD_API_SECRET_KEY")
+// func GetSercet() (secretID, secretKey, token string, isTokenUpdate bool) {
+// 	secretID = os.Getenv("TENCENTCLOUD_API_SECRET_ID")
+// 	secretKey = os.Getenv("TENCENTCLOUD_API_SECRET_KEY")
 
-	if secretID != "" && secretKey != "" {
-		return
-	}
+// 	if secretID != "" && secretKey != "" {
+// 		return
+// 	}
 
-	var err error
-	if secretID == "" || secretKey == "" {
-		glog.Info("Get secretID or secretKey from env failed, will use cloud norm!")
-		secretID, secretKey, token, isTokenUpdate, err = GetNormTmpSecret()
-		if err != nil {
-			glog.Errorf("GetNormTmpSecret error %v", err)
-			return "", "", "", false
-		}
-	}
+// 	var err error
+// 	if secretID == "" || secretKey == "" {
+// 		glog.Info("Get secretID or secretKey from env failed, will use cloud norm!")
+// 		secretID, secretKey, token, isTokenUpdate, err = GetNormTmpSecret()
+// 		if err != nil {
+// 			glog.Errorf("GetNormTmpSecret error %v", err)
+// 			return "", "", "", false
+// 		}
+// 	}
 
-	return
-}
+// 	return
+// }
 
-func GetNormTmpSecret() (string, string, string, bool, error) {
-	return cloud.GetNormCredentialInstance().GetCredential()
-}
+// func GetNormTmpSecret() (string, string, string, bool, error) {
+// 	return cloud.GetNormCredentialInstance().GetCredential()
+// }

--- a/driver/util/secret_util.go
+++ b/driver/util/secret_util.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	"os"
+
+	"github.com/golang/glog"
+	"github.com/tencentcloud/kubernetes-csi-tencentcloud/driver/cloud"
+)
+
+func GetSercet() (secretID, secretKey, token string, isTokenUpdate bool) {
+	secretID = os.Getenv("TENCENTCLOUD_API_SECRET_ID")
+	secretKey = os.Getenv("TENCENTCLOUD_API_SECRET_KEY")
+
+	if secretID != "" && secretKey != "" {
+		return
+	}
+
+	var err error
+	if secretID == "" || secretKey == "" {
+		glog.Info("Get secretID or secretKey from env failed, will use cloud norm!")
+		secretID, secretKey, token, isTokenUpdate, err = GetNormTmpSecret()
+		if err != nil {
+			glog.Errorf("GetNormTmpSecret error %v", err)
+			return "", "", "", false
+		}
+	}
+
+	return
+}
+
+func GetNormTmpSecret() (string, string, string, bool, error) {
+	return cloud.GetNormCredentialInstance().GetCredential()
+}


### PR DESCRIPTION
- 1. we verify cbs disk is attached successfully by /dev/disk/by-id/virtio-xxx. But sometimes the cbs device path is failed to create after attaching. To make pod use cbs disk normally, we get device(/dev/vdX) from another way and use os.Symlink.
- 2. if want to delete existing cbs disks with deleting TKE cluster, you can specify env `CLUSTER_ID` to cbs csi driver
- 3. dynamicly setting the volume attach limit for all nodes of cluster by flag `volume_attach_limit` to cbs csi driver
- 4. In detaching, if disk does not found, assuming the disk is detached. Oherwise csi-attacher will retry detach continuously.
- 5. To more safe, cbs csi get secretid,secretkey from norm(with tkerole by sts service). 
- 6. if set env `CLUSTER_ID`, diskname will be "$(CLUSTER_ID)/$(PVName)". if not set, will be "$(PVName)"
- 7. Compatible with the parameters supported by cbs in-tree plugin